### PR TITLE
为项目添加xml文档生成，同时打包到nuget里。

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### 原因
历史的nuget版本中，都不含有xml注释文档，导致库的使用者不太理解各类型和属性的意思。

### 修改方案
在Directory.Build.props里增加`<GenerateDocumentationFile>true</GenerateDocumentationFile>`
