### PR TITLE
修复对GetNeedVerify()为false的请求仍验证平台证书存在生的问题。

### DIFF
--- a/src/Essensoft.Paylinks.WeChatPay.Client/WeChatPayClient.cs
+++ b/src/Essensoft.Paylinks.WeChatPay.Client/WeChatPayClient.cs
@@ -24,19 +24,19 @@ public class WeChatPayClient(IHttpClientFactory httpClientFactory, IWeChatPayPla
         else
         {
             var certificateManager = certificateManagerFactory.Create(options.MchId);
-            var certificate = certificateManager.GetAvailableCertificates().OrderByDescending(c => c.EffectiveTime).FirstOrDefault() ?? throw new WeChatPayException("验签失败: 微信平台证书管理器中未找到有效平台证书");
-            if (string.IsNullOrEmpty(certificate.PublicKey))
-            {
-                throw new WeChatPayException("验签失败: 平台证书公钥为空");
-            }
+            var certificate = certificateManager.GetAvailableCertificates().OrderByDescending(c => c.EffectiveTime).FirstOrDefault();
 
-            certSerialNo = certificate.SerialNo;
-            certPublicKey = certificate.PublicKey;
+            certSerialNo = certificate?.SerialNo;
+            certPublicKey = certificate?.PublicKey;
         }
 
         if (request is IWeChatPaySecretRequest<T> secretRequest)
         {
             // 加密敏感信息
+            if (string.IsNullOrEmpty(certPublicKey))
+            {
+                throw new WeChatPayException("验签失败: 微信平台证书管理器中未找到有效平台证书");
+            }
             secretRequest.EncryptSecretRequest(certPublicKey);
         }
 


### PR DESCRIPTION
### 问题描述
WeChatPayClient在处理request时，未考虑request.GetNeedVerify()的情况下，就执行了检查平台证书的存在性要求。

### 问题影响 
造成WeChatPayClient首次下载平台证书时，因为平台证书不存在而无法下载平台证书的鸡和蛋的问题。

### 修改方案
尝试读取平台证书而不校验，需要用到平台证书时才根据实际选择不同的验证方式和逻辑。
